### PR TITLE
Gradle 9 + React Native New Architecture compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,17 +2,6 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
-buildscript {
-  repositories {
-    google()
-    jcenter()
-  }
-
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.3.1'
-  }
-}
-
 apply plugin: 'com.android.library'
 
 android {
@@ -60,7 +49,6 @@ android {
 
 repositories {
   google()
-  jcenter()
   mavenCentral()
   maven { url "https://jitpack.io" }
   maven {

--- a/android/src/main/java/org/reactnative/camera/CameraModule.java
+++ b/android/src/main/java/org/reactnative/camera/CameraModule.java
@@ -8,9 +8,6 @@ import android.widget.Toast;
 
 import com.facebook.react.bridge.*;
 import com.facebook.react.common.build.ReactBuildConfig;
-import com.facebook.react.uimanager.NativeViewHierarchyManager;
-import com.facebook.react.uimanager.UIBlock;
-import com.facebook.react.uimanager.UIManagerModule;
 import com.google.android.cameraview.AspectRatio;
 import com.google.zxing.BarcodeFormat;
 import org.reactnative.barcodedetector.BarcodeFormatUtils;
@@ -212,10 +209,9 @@ public class CameraModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void pausePreview(final int viewTag) {
         final ReactApplicationContext context = getReactApplicationContext();
-        UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
-        uiManager.addUIBlock(new UIBlock() {
+        FabricUIBlocks.addUIBlock(context, new FabricUIBlocks.UIBlock() {
             @Override
-            public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
+            public void execute(FabricUIBlocks.ViewResolver nativeViewHierarchyManager) {
                 final RNCameraView cameraView;
                 
                 try {
@@ -233,10 +229,9 @@ public class CameraModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void resumePreview(final int viewTag) {
         final ReactApplicationContext context = getReactApplicationContext();
-        UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
-        uiManager.addUIBlock(new UIBlock() {
+        FabricUIBlocks.addUIBlock(context, new FabricUIBlocks.UIBlock() {
             @Override
-            public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
+            public void execute(FabricUIBlocks.ViewResolver nativeViewHierarchyManager) {
                 final RNCameraView cameraView;
                 
                 try {
@@ -255,10 +250,9 @@ public class CameraModule extends ReactContextBaseJavaModule {
   public void takePicture(final ReadableMap options, final int viewTag, final Promise promise) {
     final ReactApplicationContext context = getReactApplicationContext();
     final File cacheDirectory = mScopedContext.getCacheDirectory();
-    UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
-    uiManager.addUIBlock(new UIBlock() {
+    FabricUIBlocks.addUIBlock(context, new FabricUIBlocks.UIBlock() {
       @Override
-      public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
+      public void execute(FabricUIBlocks.ViewResolver nativeViewHierarchyManager) {
           RNCameraView cameraView = (RNCameraView) nativeViewHierarchyManager.resolveView(viewTag);
           try {
             if (cameraView.isCameraOpened()) {
@@ -277,11 +271,9 @@ public class CameraModule extends ReactContextBaseJavaModule {
   public void record(final ReadableMap options, final int viewTag, final Promise promise) {
       final ReactApplicationContext context = getReactApplicationContext();
       final File cacheDirectory = mScopedContext.getCacheDirectory();
-      UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
-
-      uiManager.addUIBlock(new UIBlock() {
+      FabricUIBlocks.addUIBlock(context, new FabricUIBlocks.UIBlock() {
           @Override
-          public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
+          public void execute(FabricUIBlocks.ViewResolver nativeViewHierarchyManager) {
               final RNCameraView cameraView;
 
               try {
@@ -301,10 +293,9 @@ public class CameraModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void stopRecording(final int viewTag) {
       final ReactApplicationContext context = getReactApplicationContext();
-      UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
+      FabricUIBlocks.addUIBlock(context, new FabricUIBlocks.UIBlock() {
           @Override
-          public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
+          public void execute(FabricUIBlocks.ViewResolver nativeViewHierarchyManager) {
               final RNCameraView cameraView;
 
               try {
@@ -322,10 +313,9 @@ public class CameraModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void getCameraParameters(final int viewTag, final Promise promise) {
     final ReactApplicationContext context = getReactApplicationContext();
-    UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
-    uiManager.addUIBlock(new UIBlock() {
+    FabricUIBlocks.addUIBlock(context, new FabricUIBlocks.UIBlock() {
       @Override
-      public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
+      public void execute(FabricUIBlocks.ViewResolver nativeViewHierarchyManager) {
         final RNCameraView cameraView;
 
         try {
@@ -349,10 +339,9 @@ public class CameraModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void getSupportedRatios(final int viewTag, final Promise promise) {
       final ReactApplicationContext context = getReactApplicationContext();
-      UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
+      FabricUIBlocks.addUIBlock(context, new FabricUIBlocks.UIBlock() {
           @Override
-          public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
+          public void execute(FabricUIBlocks.ViewResolver nativeViewHierarchyManager) {
               final RNCameraView cameraView;
               try {
                   cameraView = (RNCameraView) nativeViewHierarchyManager.resolveView(viewTag);
@@ -375,10 +364,9 @@ public class CameraModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void getAvailablePictureSizes(final String ratio, final int viewTag, final Promise promise) {
         final ReactApplicationContext context = getReactApplicationContext();
-        UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
-        uiManager.addUIBlock(new UIBlock() {
+        FabricUIBlocks.addUIBlock(context, new FabricUIBlocks.UIBlock() {
             @Override
-            public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
+            public void execute(FabricUIBlocks.ViewResolver nativeViewHierarchyManager) {
                 final RNCameraView cameraView;
                 
                 try {

--- a/android/src/main/java/org/reactnative/camera/FabricUIBlocks.java
+++ b/android/src/main/java/org/reactnative/camera/FabricUIBlocks.java
@@ -1,0 +1,45 @@
+package org.reactnative.camera;
+
+import android.view.View;
+
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.UiThreadUtil;
+import com.facebook.react.uimanager.IllegalViewOperationException;
+import com.facebook.react.uimanager.UIManagerHelper;
+
+/**
+ * Arch-agnostic replacement for Paper's UIManagerModule.addUIBlock + NativeViewHierarchyManager,
+ * neither of which exists under the New Architecture (UIManagerModule.getNativeModule() returns
+ * null under bridgeless, which crashed every camera module method). Runs the block on the UI
+ * thread and resolves views through UIManagerHelper, which routes to the correct UIManager for
+ * the tag on either architecture.
+ */
+public class FabricUIBlocks {
+
+  public interface UIBlock {
+    void execute(ViewResolver viewResolver);
+  }
+
+  public static class ViewResolver {
+    private final ReactContext context;
+
+    ViewResolver(ReactContext context) {
+      this.context = context;
+    }
+
+    public View resolveView(int tag) {
+      com.facebook.react.bridge.UIManager uiManager = UIManagerHelper.getUIManagerForReactTag(context, tag);
+      if (uiManager == null) throw new IllegalViewOperationException("No UIManager found for tag " + tag);
+      return uiManager.resolveView(tag);
+    }
+  }
+
+  public static void addUIBlock(final ReactContext context, final UIBlock block) {
+    UiThreadUtil.runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        block.execute(new ViewResolver(context));
+      }
+    });
+  }
+}

--- a/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
@@ -13,7 +13,6 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableArray;
-import com.facebook.react.uimanager.UIManagerModule;
 import com.google.android.cameraview.CameraView;
 import com.google.zxing.Result;
 import org.reactnative.camera.events.*;
@@ -161,7 +160,9 @@ public class RNCameraViewHelper {
   public static void emitMountErrorEvent(ViewGroup view, String error) {
     CameraMountErrorEvent event = CameraMountErrorEvent.obtain(view.getId(), error);
     ReactContext reactContext = (ReactContext) view.getContext();
-    reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+    com.facebook.react.uimanager.events.EventDispatcher eventDispatcher =
+        com.facebook.react.uimanager.UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.getId());
+    if (eventDispatcher != null) eventDispatcher.dispatchEvent(event);
   }
 
   // Camera ready event
@@ -169,7 +170,9 @@ public class RNCameraViewHelper {
   public static void emitCameraReadyEvent(ViewGroup view) {
     CameraReadyEvent event = CameraReadyEvent.obtain(view.getId());
     ReactContext reactContext = (ReactContext) view.getContext();
-    reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+    com.facebook.react.uimanager.events.EventDispatcher eventDispatcher =
+        com.facebook.react.uimanager.UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.getId());
+    if (eventDispatcher != null) eventDispatcher.dispatchEvent(event);
   }
 
   // Picture saved event
@@ -177,7 +180,9 @@ public class RNCameraViewHelper {
   public static void emitPictureSavedEvent(ViewGroup view, WritableMap response) {
     PictureSavedEvent event = PictureSavedEvent.obtain(view.getId(), response);
     ReactContext reactContext = (ReactContext) view.getContext();
-    reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+    com.facebook.react.uimanager.events.EventDispatcher eventDispatcher =
+        com.facebook.react.uimanager.UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.getId());
+    if (eventDispatcher != null) eventDispatcher.dispatchEvent(event);
   }
 
   // Picture taken event
@@ -185,7 +190,9 @@ public class RNCameraViewHelper {
   public static void emitPictureTakenEvent(ViewGroup view) {
     PictureTakenEvent event = PictureTakenEvent.obtain(view.getId());
     ReactContext reactContext = (ReactContext) view.getContext();
-    reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+    com.facebook.react.uimanager.events.EventDispatcher eventDispatcher =
+        com.facebook.react.uimanager.UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.getId());
+    if (eventDispatcher != null) eventDispatcher.dispatchEvent(event);
   }
 
   // Face detection events
@@ -193,13 +200,17 @@ public class RNCameraViewHelper {
   public static void emitFacesDetectedEvent(ViewGroup view, WritableArray data) {
     FacesDetectedEvent event = FacesDetectedEvent.obtain(view.getId(), data);
     ReactContext reactContext = (ReactContext) view.getContext();
-    reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+    com.facebook.react.uimanager.events.EventDispatcher eventDispatcher =
+        com.facebook.react.uimanager.UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.getId());
+    if (eventDispatcher != null) eventDispatcher.dispatchEvent(event);
   }
 
   public static void emitFaceDetectionErrorEvent(ViewGroup view, RNFaceDetector faceDetector) {
     FaceDetectionErrorEvent event = FaceDetectionErrorEvent.obtain(view.getId(), faceDetector);
     ReactContext reactContext = (ReactContext) view.getContext();
-    reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+    com.facebook.react.uimanager.events.EventDispatcher eventDispatcher =
+        com.facebook.react.uimanager.UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.getId());
+    if (eventDispatcher != null) eventDispatcher.dispatchEvent(event);
   }
 
   // Barcode detection events
@@ -207,13 +218,17 @@ public class RNCameraViewHelper {
   public static void emitBarcodesDetectedEvent(ViewGroup view, WritableArray barcodes) {
     BarcodesDetectedEvent event = BarcodesDetectedEvent.obtain(view.getId(), barcodes);
     ReactContext reactContext = (ReactContext) view.getContext();
-    reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+    com.facebook.react.uimanager.events.EventDispatcher eventDispatcher =
+        com.facebook.react.uimanager.UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.getId());
+    if (eventDispatcher != null) eventDispatcher.dispatchEvent(event);
   }
 
   public static void emitBarcodeDetectionErrorEvent(ViewGroup view, RNBarcodeDetector barcodeDetector) {
     BarcodeDetectionErrorEvent event = BarcodeDetectionErrorEvent.obtain(view.getId(), barcodeDetector);
     ReactContext reactContext = (ReactContext) view.getContext();
-    reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+    com.facebook.react.uimanager.events.EventDispatcher eventDispatcher =
+        com.facebook.react.uimanager.UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.getId());
+    if (eventDispatcher != null) eventDispatcher.dispatchEvent(event);
   }
 
   // Bar code read event
@@ -221,7 +236,9 @@ public class RNCameraViewHelper {
   public static void emitBarCodeReadEvent(ViewGroup view, Result barCode, int width, int height) {
     BarCodeReadEvent event = BarCodeReadEvent.obtain(view.getId(), barCode, width,  height);
     ReactContext reactContext = (ReactContext) view.getContext();
-    reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+    com.facebook.react.uimanager.events.EventDispatcher eventDispatcher =
+        com.facebook.react.uimanager.UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.getId());
+    if (eventDispatcher != null) eventDispatcher.dispatchEvent(event);
   }
 
   // Text recognition event
@@ -229,7 +246,9 @@ public class RNCameraViewHelper {
   public static void emitTextRecognizedEvent(ViewGroup view, WritableArray data) {
     TextRecognizedEvent event = TextRecognizedEvent.obtain(view.getId(), data);
     ReactContext reactContext = (ReactContext) view.getContext();
-    reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(event);
+    com.facebook.react.uimanager.events.EventDispatcher eventDispatcher =
+        com.facebook.react.uimanager.UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.getId());
+    if (eventDispatcher != null) eventDispatcher.dispatchEvent(event);
   }
 
   // Utilities


### PR DESCRIPTION
Two fixes required by CNTRAL Mobile's React Native 0.82 / New Architecture migration (cntral/cntral_mobile#5233):

1. **Remove `jcenter()`** (the obsolete AGP 3.3.1 buildscript block and the module-level repository): removed in Gradle 9; every remaining artifact resolves from mavenCentral/google.
2. **Replace 18 Paper-only `UIManagerModule` call sites**: under the bridgeless New Architecture, `getNativeModule(UIManagerModule.class)` returns null, so every camera event emission (`RNCameraViewHelper`, 10 sites) and every module method resolving the camera view via `addUIBlock` (`CameraModule`, 8 sites) crashed with an NPE the moment the camera screen emitted its first event. Events now dispatch through `UIManagerHelper.getEventDispatcherForReactTag`, and a small `FabricUIBlocks` shim replaces `addUIBlock`/`NativeViewHierarchyManager` with UI-thread `UIManagerHelper`-based view resolution that works on both architectures (call-site bodies unchanged).

Verified on a real device (Kyocera E6920): full camera e2e suite 3/3 — flash modes, timer, photo capture, video record + playback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)